### PR TITLE
Arrow shape (WIP)

### DIFF
--- a/crates/bevy_vello_graphics/src/arrow.rs
+++ b/crates/bevy_vello_graphics/src/arrow.rs
@@ -1,0 +1,80 @@
+use bevy::{math::DVec2, prelude::*};
+use bevy_vello::prelude::*;
+#[cfg(feature = "motiongfx")]
+use motiongfx_core::f32lerp::F32Lerp;
+
+use super::VelloVector;
+
+#[derive(Component, Default, Debug, Clone, Copy)]
+pub struct VelloArrow {
+    pub head: ArrowHead,
+    pub size: f32,
+    pub offset: f32,
+    pub rotation: f32,
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub enum ArrowHead {
+    #[default]
+    Triangle,
+    Square,
+    Circle,
+}
+
+impl VelloArrow {
+    pub fn new(head: ArrowHead, size: f32, offset: f32, rotation: f32) -> Self {
+        Self {
+            head,
+            size,
+            offset,
+            rotation,
+        }
+    }
+
+    pub fn new_simple(head: ArrowHead, size: f32) -> Self {
+        Self {
+            head,
+            size,
+            ..default()
+        }
+    }
+
+    pub fn with_head(mut self, head: ArrowHead) -> Self {
+        self.head = head;
+        self
+    }
+
+    pub fn with_size(mut self, size: f32) -> Self {
+        self.size = size;
+        self
+    }
+
+    pub fn with_offset(mut self, offset: f32) -> Self {
+        self.offset = offset;
+        self
+    }
+
+    pub fn with_rotation(mut self, angle: f32) -> Self {
+        self.rotation = angle;
+        self
+    }
+}
+
+impl VelloVector for VelloArrow {
+    fn shape(&self) -> impl kurbo::Shape {
+        // kurbo::Triangle::new()
+        todo!();
+    }
+}
+
+#[cfg(feature = "motiongfx")]
+impl F32Lerp for VelloArrow {
+    fn f32lerp(&self, rhs: &Self, t: f32) -> Self {
+        VelloArrow {
+            head: self.head,
+            size: self.size.f32lerp(&rhs.size, t),
+            offset: self.offset.f32lerp(&rhs.offset, t),
+            rotation: self.rotation.f32lerp(&rhs.rotation, t),
+        }
+    }
+}

--- a/crates/bevy_vello_graphics/src/lib.rs
+++ b/crates/bevy_vello_graphics/src/lib.rs
@@ -7,6 +7,7 @@ use line::VelloLine;
 use rect::VelloRect;
 use stroke::Stroke;
 
+pub mod arrow;
 pub mod bezpath;
 pub mod brush;
 pub mod circle;
@@ -17,7 +18,10 @@ pub mod stroke;
 
 pub mod prelude {
     pub use crate::VelloGraphicsPlugin;
-    pub use crate::{bezpath::VelloBezPath, circle::VelloCircle, line::VelloLine, rect::VelloRect};
+    pub use crate::{
+        arrow::VelloArrow, bezpath::VelloBezPath, circle::VelloCircle, line::VelloLine,
+        rect::VelloRect,
+    };
     pub use crate::{brush::Brush, fill::Fill, stroke::Stroke};
 }
 

--- a/examples/vello_basic.rs
+++ b/examples/vello_basic.rs
@@ -32,7 +32,7 @@ fn vello_basic(mut commands: Commands) {
 
     let mut circle = commands.build_fsvector(
         Transform::from_xyz(200.0, 0.0, 0.0),
-        VelloCircle::new(50.0),
+        VelloArrow::default().with_size(50.0),
         Fill::new().with_color(palette.get(ColorKey::Purple)),
         Stroke::new(4.0).with_color(palette.get(ColorKey::Purple) * 1.5),
     );
@@ -120,9 +120,9 @@ fn vello_basic(mut commands: Commands) {
         commands
             .add_motion(
                 act!(
-                    (circle.id, VelloCircle),
-                    start = { circle.vector }.radius,
-                    end = circle.vector.radius + 50.0,
+                    (circle.id, VelloArrow),
+                    start = { circle.vector }.size,
+                    end = circle.vector.size + 50.0,
                 )
                 .animate(1.0),
             )
@@ -131,9 +131,9 @@ fn vello_basic(mut commands: Commands) {
         commands
             .add_motion(
                 act!(
-                    (circle.id, VelloCircle),
-                    start = { circle.vector }.radius,
-                    end = circle.vector.radius - 50.0,
+                    (circle.id, VelloArrow),
+                    start = { circle.vector }.size,
+                    end = circle.vector.size - 50.0,
                 )
                 .animate(1.0),
             )


### PR DESCRIPTION
fixes: https://github.com/voxell-tech/bevy_vello_graphics/issues/1 (not sure whether i should migrate over to this [new repo](https://github.com/voxell-tech/bevy_vello_graphics) yet).

WIP: Again waiting for https://github.com/linebender/kurbo/pull/331 for different `ArrowHead` shapes. And also wait until https://github.com/linebender/kurbo/pull/350 gets merged. if it doesn't get merged then e can create triangles building on top of other primitives and curves.

For now though there some design decisions to be made, namely how should the arrow connect to another shape? maybe there should be a private `Shape`/`DVec2` field like `parent` or something which `VelloArrow` inherits a position, rotation, colour, etc. from?